### PR TITLE
Fix the US Core package id

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -23,7 +23,7 @@
   "canonicalBase": "http://hl7.org/fhir/us/Davinci-drug-formulary",
   "dependencyList": [
     {
-      "package": "hl7.fhir.us.core.r4",
+      "package": "hl7.fhir.us.core",
       "version": "current",
       "name": "uscore",
       "location": "http://hl7.org/fhir/us/core"

--- a/resources/ig-new.json
+++ b/resources/ig-new.json
@@ -25,7 +25,7 @@
   "dependsOn" : [{
     "id" : "uscore",
     "uri" : "http://hl7.org/fhir/us/core",
-    "packageId" : "hl7.fhir.us.core.r4",
+    "packageId" : "hl7.fhir.us.core",
     "version" : "current"
   }],
   "definition" : {

--- a/resources/ig-new.xml
+++ b/resources/ig-new.xml
@@ -22,7 +22,7 @@
   <fhirVersion value="4.0.0"/>
   <dependsOn id="uscore">
     <uri value="http://hl7.org/fhir/us/core"/>
-    <packageId value="hl7.fhir.us.core.r4"/>
+    <packageId value="hl7.fhir.us.core"/>
     <version value="current"/>
   </dependsOn>
   <definition>


### PR DESCRIPTION
Change it from `hl7.fhir.us.core.r4` to `hl7.fhir.us.core`, per: https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/US.20Core.20package.20name.20correction.3A/near/168088327