### PR TITLE
Fix null SD extensions

### DIFF
--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -1,4 +1,5 @@
 Alias: $GeoJSONExtension = http://hl7.org/fhir/StructureDefinition/location-boundary-geojson
+Alias: $StandardsStatusExtension = http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
 Alias: $PlanNetInsuranceProductTypeVS = http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS
 Alias: $PlanNetInsuranceProductTypeCS = http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsuranceProductTypeCS
 

--- a/input/fsh/Formulary.fsh
+++ b/input/fsh/Formulary.fsh
@@ -248,8 +248,7 @@ Id:             usdf-PayerInsurancePlanBulkDataGraphDefinition
 Title:          "Payer Insurance Plan Bulk Data Graph Definition"
 Description:    "A GraphDefinition defining a graph of resources to return in a query for a Formulary related Payer Insurance Plan Bulk Data request."
 
-* ^extension[2].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
-* ^extension[2].valueCode = #draft
+* ^extension[$StandardsStatusExtension].valueCode = #draft
 
 //* url = "http://hl7.org/fhir/us/davinci-drug-formulary/GraphDefinition/usdf-PayerInsurancePlanBulkDataGraphDefinition"
 * name = "PayerInsurancePlanGraphDefinition"
@@ -295,8 +294,7 @@ Id:             usdf-FormularyBulkDataGraphDefinition
 Title:          "Formulary Bulk Data Graph Definition"
 Description:    "A GraphDefinition defining a graph of resources to return in a query for a Formulary related Bulk Data request."
 
-* ^extension[2].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
-* ^extension[2].valueCode = #draft
+* ^extension[$StandardsStatusExtension].valueCode = #draft
 
 //* url = "http://hl7.org/fhir/us/davinci-drug-formulary/GraphDefinition/usdf-PayerInsurancePlanBulkDataGraphDefinition"
 * name = "FormularyGraphDefinition"


### PR DESCRIPTION
SUSHI 2.9.0 stopped inheriting some SD extensions that were previously inherited (see https://github.com/FHIR/sushi/pull/1212). As a result, SD definitions start w/ fewer root-level extensions. When a profile definition added an SD extension by index (e.g., `^extension[2]`), this ended up causing gaps in the extension array since `extension[0]` and `extension[1]` are no longer inherited.

This PR refers to SD extensions by URL rather than by index in order to avoid unintentional gaps in the extension array. 